### PR TITLE
specify user and file for ssl renewal cronjob

### DIFF
--- a/ansible/ssl.yml
+++ b/ansible/ssl.yml
@@ -35,7 +35,8 @@
 
 - name: ensure dehydrated cron job is configured
   cron:
-    name: renew changed or expiring letsencrypt certificates
+    cron_file: ssl
     minute: 0
     hour: 0
+    user: root
     job: "dehydrated --cron | grep 'Done!' >/dev/null && systemctl reload nginx"


### PR DESCRIPTION
this should ensure letsencrypt ssl certificates automatically
renew when they expire.